### PR TITLE
[🔀 Member-Read] Config-server 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 
     // spring cloud
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
 
     // Databases / JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'

--- a/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
@@ -22,6 +22,12 @@ public class MemberCreateEvent {
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
                 .createdAt(createdAt)
+                .point(0)
+                .grade("default") // 정책 결정 필요
+                .followerCount(0)
+                .followingCount(0)
+                .feedCount(0)
+                .shortsCount(0)
                 .build();
     }
 }

--- a/src/main/java/com/mulmeong/member/read/MemberReadApplication.java
+++ b/src/main/java/com/mulmeong/member/read/MemberReadApplication.java
@@ -2,12 +2,13 @@ package com.mulmeong.member.read;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 
+@RefreshScope
 @SpringBootApplication
 public class MemberReadApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MemberReadApplication.class, args);
     }
-
 }

--- a/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
@@ -52,6 +52,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, MemberCreateEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(memberCreateEventConsumerFactory());
+        factory.getContainerProperties().setGroupId(groupId);
         return factory;
     }
 
@@ -67,6 +68,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, MemberNicknameUpdateEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(nicknameUpdateEventConsumerFactory());
+        factory.getContainerProperties().setGroupId(groupId);
         return factory;
     }
 
@@ -82,6 +84,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, MemberProfileImgUpdateEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(profileUpdateEventConsumerFactory());
+        factory.getContainerProperties().setGroupId(groupId);
         return factory;
     }
 }

--- a/src/main/java/com/mulmeong/member/read/common/healthcheck/HealthCheckController.java
+++ b/src/main/java/com/mulmeong/member/read/common/healthcheck/HealthCheckController.java
@@ -1,4 +1,4 @@
-package com.mulmeong.member.read.common.healthcheck.healthcheck;
+package com.mulmeong.member.read.common.healthcheck;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
@@ -6,6 +6,7 @@ import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
 import com.mulmeong.member.read.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
@@ -16,20 +17,17 @@ public class KafkaConsumer {
 
     private final MemberService memberService;
 
-    @KafkaListener(topics = "member-created", groupId = "member-read",
-            containerFactory = "memberCreateEventListener")
+    @KafkaListener(topics = "member-created", containerFactory = "memberCreateEventListener")
     public void handleMemberCreatedEvent(MemberCreateEvent event) {
         memberService.createMember(event);
     }
 
-    @KafkaListener(topics = "nickname-updated", groupId = "member-read",
-            containerFactory = "nicknameUpdateEventListener")
+    @KafkaListener(topics = "nickname-updated", containerFactory = "nicknameUpdateEventListener")
     public void handleNicknameUpdatedEvent(MemberNicknameUpdateEvent event) {
         memberService.updateNickname(event);
     }
 
-    @KafkaListener(topics = "profile-img-updated", groupId = "member-read",
-            containerFactory = "profileUpdateEventListener")
+    @KafkaListener(topics = "profile-img-updated", containerFactory = "profileUpdateEventListener")
     public void handleProfileImgUpdatedEvent(MemberProfileImgUpdateEvent event) {
         memberService.updateProfileImage(event);
     }

--- a/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
+++ b/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
@@ -3,19 +3,23 @@ package com.mulmeong.member.read.member.presentation;
 import com.mulmeong.member.read.common.response.BaseResponse;
 import com.mulmeong.member.read.member.application.MemberService;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "회원 조회 API", description = "회원 조회 API")
+@RequestMapping("/v1/members")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/members")
 public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(summary = "회원 프로필 조회", description = "회원 프로필 화면에 필요한 정보와 회원의 포인트, 뱃지 등을 조회합니다.")
     @GetMapping("/{nickname}/profile")
     public BaseResponse<MemberProfileDto> getMemberProfile(@PathVariable String nickname) {
         return new BaseResponse<>(memberService.getMemberProfile(nickname));


### PR DESCRIPTION
### 📅 2024.11.20

### 🌵 Branch
feature/config/5 → develop

### 📢 Description
- 의존성 추가 implementation 'org.springframework.cloud:spring-cloud-starter-config'
- @RefreshScope 추가
-  yml 수정
- ♻️ refactor: kafka group-id 값을 yml에서 가져오도록 수정
- 🚚 rename: 헬스체크 경로 수정
- 📝 docs: 스웨거 주석 추가

### 💬 Issue Number
- #9

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
Release 반영시, 그 전에 github secrets에 yml 수정 반영 및 config github에 yml이 커밋/푸쉬 되어야 본격 config 서버의 값을 import할 수 있습니다.