### PR TITLE
 [🔀 Member-Read] KafkaConfig 리팩토링 및 조회 API 2개 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     // spring boot starter
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
@@ -23,7 +23,7 @@ public class MemberCreateEvent {
                 .profileImageUrl(profileImageUrl)
                 .createdAt(createdAt)
                 .point(0)
-                .grade("default") // 정책 결정 필요
+                .grade("default") //todo : RewardService에서 계산한 등급으로 변경
                 .followerCount(0)
                 .followingCount(0)
                 .feedCount(0)

--- a/src/main/java/com/mulmeong/member/read/MemberReadApplication.java
+++ b/src/main/java/com/mulmeong/member/read/MemberReadApplication.java
@@ -2,9 +2,11 @@ package com.mulmeong.member.read;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 
 @RefreshScope
+@EnableDiscoveryClient
 @SpringBootApplication
 public class MemberReadApplication {
 

--- a/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
@@ -3,87 +3,107 @@ package com.mulmeong.member.read.common.config;
 import com.mulmeong.event.member.MemberCreateEvent;
 import com.mulmeong.event.member.MemberNicknameUpdateEvent;
 import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.Map;
 
-
+/**
+ * Kafka Consumer 설정 클래스.
+ * Generic 타입을 사용해 Boilerplate 코드를 최대한 줄이도록 하였습니다.
+ *
+ */
 @EnableKafka
 @Configuration
 public class KafkaConsumerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
-    private String bootstrapServers;
+    private String bootstrapServer;
 
     @Value("${spring.kafka.consumer.group-id}")
     private String groupId;
 
+
+    /**
+     * 아래 코드들은 이벤트가 생성될 때 마다 작성해야 하는 코드입니다.
+     * 특정 이벤트의 메시지를 소비하는 Kafka Listener 컨테이너 팩토리를 생성합니다.
+     *
+     * @return {@link KafkaListenerContainerFactory} Kafka Listener가 사용하는 기본 Consumer Factory
+     */
+    /* 회원가입 후 이벤트 리스너 */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MemberCreateEvent> memberCreateEventListener() {
+        return kafkaListenerContainerFactory(MemberCreateEvent.class);
+    }
+
+    /* 닉네임 수정 후 이벤트 리스너 */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MemberNicknameUpdateEvent> nicknameUpdateEventListener() {
+        return kafkaListenerContainerFactory(MemberNicknameUpdateEvent.class);
+    }
+
+    /* 프로필사진 수정 후 이벤트 리스너 */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MemberProfileImgUpdateEvent> profileUpdateEventListener() {
+        return kafkaListenerContainerFactory(MemberProfileImgUpdateEvent.class);
+    }
+
+    // =================================================================
+    // 아래는 공통 설정입니다.
+
     /**
      * {@link CommonJsonDeserializer} 에서 JSON 데이터를 역직렬화하는 설정을 가져옵니다.
+     * Consumer은 해당 설정에 맞게 JSON 데이터를 역직렬화하여 사용합니다.
      *
      * @return Kafka 컨슈머 설정을 포함하는 Map
      */
     @Bean
     public Map<String, Object> readConsumerConfigs() {
-        return CommonJsonDeserializer.getStringObjectMap(bootstrapServers, groupId);
+        return CommonJsonDeserializer.getStringObjectMap(bootstrapServer, groupId);
     }
 
     /**
-     * 아래 내용부터는 특정 이벤트의 메시지를 처리하기 위한 ConsumerFactory와 ListenerContainerFactory를 생성합니다.
+     * 특정 메시지 타입에 맞게 ConsumerFactory를 생성합니다.
      *
-     * @return 특정 이벤트 타입을 수신하는 컨슈머 설정 Map
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return DefaultKafkaConsumerFactory, Kafka Listener가 사용하는 기본 Consumer Factory
      */
-
-    /* 회원가입 후 이벤트 리스너 */
     @Bean
-    public ConsumerFactory<String, MemberCreateEvent> memberCreateEventConsumerFactory() {
-
-        return new DefaultKafkaConsumerFactory<>(readConsumerConfigs());
+    public <T> ConsumerFactory<String, T> consumerFactory(Class<T> messageType) {
+        return new DefaultKafkaConsumerFactory<>(Map.of(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer,
+                ConsumerConfig.GROUP_ID_CONFIG, groupId,
+                ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class,
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class,
+                ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class.getName(),
+                ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName(),
+                JsonDeserializer.TRUSTED_PACKAGES, "com.mulmeong.event.member",
+                JsonDeserializer.VALUE_DEFAULT_TYPE, messageType
+        ));
     }
 
+    /**
+     * 위의 consumerFactory와 컨테이너 프로퍼티에 group-id 를 설정한 '컨테이너 팩토리'를 생성합니다.
+     * 이 컨테이너 팩토리는 다중 스레드에서 Kafka 메시지를 처리하며, 이 설정을 통해 KafkaListener가 메시지를 소비합니다.
+     *
+     * @param messageType 제네릭으로 선언한 Event 객체
+     * @return ConcurrentKafkaListenerContainerFactory, 다중 스레드에서 Kafka 메시지를 처리하는 컨테이너 팩토리
+     */
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, MemberCreateEvent> memberCreateEventListener() {
-        ConcurrentKafkaListenerContainerFactory<String, MemberCreateEvent> factory =
+    public <T> ConcurrentKafkaListenerContainerFactory<String, T> kafkaListenerContainerFactory(Class<T> messageType) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(memberCreateEventConsumerFactory());
-        factory.getContainerProperties().setGroupId(groupId);
-        return factory;
-    }
-
-    /* 닉네임 수정 후 이벤트 리스너 */
-    @Bean
-    public ConsumerFactory<String, MemberNicknameUpdateEvent> nicknameUpdateEventConsumerFactory() {
-
-        return new DefaultKafkaConsumerFactory<>(readConsumerConfigs());
-    }
-
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, MemberNicknameUpdateEvent> nicknameUpdateEventListener() {
-        ConcurrentKafkaListenerContainerFactory<String, MemberNicknameUpdateEvent> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(nicknameUpdateEventConsumerFactory());
-        factory.getContainerProperties().setGroupId(groupId);
-        return factory;
-    }
-
-    /* 프로필사진 수정 후 이벤트 리스너 */
-    @Bean
-    public ConsumerFactory<String, MemberProfileImgUpdateEvent> profileUpdateEventConsumerFactory() {
-
-        return new DefaultKafkaConsumerFactory<>(readConsumerConfigs());
-    }
-
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, MemberProfileImgUpdateEvent> profileUpdateEventListener() {
-        ConcurrentKafkaListenerContainerFactory<String, MemberProfileImgUpdateEvent> factory =
-                new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(profileUpdateEventConsumerFactory());
+        factory.setConsumerFactory(consumerFactory(messageType));
         factory.getContainerProperties().setGroupId(groupId);
         return factory;
     }

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberService.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberService.java
@@ -3,6 +3,7 @@ package com.mulmeong.member.read.member.application;
 import com.mulmeong.event.member.MemberCreateEvent;
 import com.mulmeong.event.member.MemberNicknameUpdateEvent;
 import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.member.read.member.dto.out.CompactProfileDto;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
 
 public interface MemberService {
@@ -13,5 +14,9 @@ public interface MemberService {
 
     void updateProfileImage(MemberProfileImgUpdateEvent memberProfileImgUpdateEvent);
 
-    MemberProfileDto getMemberProfile(String nickname);
+    MemberProfileDto getProfileByNickname(String nickname);
+
+    MemberProfileDto getProfileByMemberUuid(String memberUuid);
+
+    CompactProfileDto getCompactProfile(String memberUuid);
 }

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberServiceImpl.java
@@ -53,7 +53,7 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public void updateProfileImage(MemberProfileImgUpdateEvent event) {
-        updateMemberField(event.getMemberUuid(), "nickname", event.getProfileImgUrl());
+        updateMemberField(event.getMemberUuid(), "profileImageUrl", event.getProfileImgUrl());
     }
 
     /**

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberServiceImpl.java
@@ -5,6 +5,7 @@ import com.mulmeong.event.member.MemberNicknameUpdateEvent;
 import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
 import com.mulmeong.member.read.common.exception.BaseException;
 import com.mulmeong.member.read.member.document.Member;
+import com.mulmeong.member.read.member.dto.out.CompactProfileDto;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
 import com.mulmeong.member.read.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원 Read DB 생성.
+     * Write DB에서 회원 생성 이벤트를 받아 처리.
      *
      * @param event 회원 생성 Event
      */
@@ -36,7 +38,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원 Read DB의 닉네임 수정.
-     * {@link com.mulmeong.member.read.member.kafka.KafkaConsumer}로부터 Kafka 이벤트를 받아 처리.
+     * Write DB에서 닉네임 수정 이벤트를 받아 처리.
      *
      * @param event 닉네임 수정 Event
      */
@@ -47,7 +49,7 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원 Read DB의 프로필 이미지 수정.
-     * {@link com.mulmeong.member.read.member.kafka.KafkaConsumer}로부터 Kafka 이벤트를 받아 처리.
+     * Write DB에서 프로필 이미지 수정 이벤트를 받아 처리.
      *
      * @param event 프로필 이미지 수정 Event.
      */
@@ -58,23 +60,51 @@ public class MemberServiceImpl implements MemberService {
 
     /**
      * 회원 프로필 조회 API
-     * 등록/수정이 되지 않은 필드들은 null로 반환됩니다.
+     * 등록/수정이 되지 않은 필드들은 기본값으로 반환.(예: 집계데이터들).
      *
-     * @param nickname 회원 닉네임(MemberUuid 노출 최소화를 위해 API 정의서에 닉네임으로 정의)
-     * @return 회원 프로필DTO
+     * @param nickname 회원 닉네임
+     * @return 회원 프로필 DTO(Member Document와 같음)
      */
     @Override
-    public MemberProfileDto getMemberProfile(String nickname) {
+    public MemberProfileDto getProfileByNickname(String nickname) {
         return memberRepository.findByNickname(nickname)
-                .map(MemberProfileDto::fromEntity)
+                .map(MemberProfileDto::fromDocument)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
     }
 
     /**
-     * 회원 필드 업데이트 메서드.
+     * 회원 프로필 조회 API
+     * 등록/수정이 되지 않은 필드들은 기본값으로 반환됩니다.(예: 집계데이터들).
+     *
+     * @param memberUuid 회원 닉네임
+     * @return 회원 프로필 DTO(Member Document와 같음)
+     */
+    @Override
+    public MemberProfileDto getProfileByMemberUuid(String memberUuid) {
+        return memberRepository.findByMemberUuid(memberUuid)
+                .map(MemberProfileDto::fromDocument)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+    }
+
+    /**
+     * 회원 Compact 프로필 조회 API
+     * 피드, 쇼츠 등에서 사용되는 간단한 회원 프로필 조회.
+     *
+     * @param memberUuid 회원 닉네임
+     * @return 회원 프로필 DTO중 일부
+     */
+    @Override
+    public CompactProfileDto getCompactProfile(String memberUuid) {
+        return memberRepository.findByMemberUuid(memberUuid)
+                .map(CompactProfileDto::fromDocument)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
+    }
+
+    /**
+     * 회원 필드 업데이트하는 private 메서드.
      *
      * @param memberUuid 업데이트할 회원의 uuid
-     * @param field      업데이트할 필드
+     * @param field      업데이트할 필드(닉네임, 프로필 이미지 URL...)
      * @param value      업데이트할 값
      */
     private void updateMemberField(String memberUuid, String field, Object value) {

--- a/src/main/java/com/mulmeong/member/read/member/document/Badge.java
+++ b/src/main/java/com/mulmeong/member/read/member/document/Badge.java
@@ -1,4 +1,4 @@
-package com.mulmeong.member.read.member.vo;
+package com.mulmeong.member.read.member.document;
 
 import lombok.Getter;
 

--- a/src/main/java/com/mulmeong/member/read/member/document/Member.java
+++ b/src/main/java/com/mulmeong/member/read/member/document/Member.java
@@ -1,7 +1,6 @@
 package com.mulmeong.member.read.member.document;
 
 
-import com.mulmeong.member.read.member.vo.Badge;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,7 +27,6 @@ public class Member {
     private Integer point;
     private String grade;
     private Badge equippedBadge;
-
     // todo : 화면에 따른 기타 집계 데이터 추가/수정 필요
     private Integer followerCount;
     private Integer followingCount;

--- a/src/main/java/com/mulmeong/member/read/member/dto/out/CompactProfileDto.java
+++ b/src/main/java/com/mulmeong/member/read/member/dto/out/CompactProfileDto.java
@@ -5,42 +5,26 @@ import com.mulmeong.member.read.member.document.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
-@Builder
 @AllArgsConstructor
-@NoArgsConstructor
-public class MemberProfileDto {
-    // Member Document에 있는 모든 필드
-
+@Builder
+public class CompactProfileDto {
     private String memberUuid;
     private String nickname;
     private String profileImageUrl;
-    private LocalDateTime createdAt;
     private Integer point;
     private String grade;
     private Badge equippedBadge;
-    private Integer followerCount;
-    private Integer followingCount;
-    private Integer feedCount;
-    private Integer shortsCount;
 
-    public static MemberProfileDto fromDocument(Member member) {
-        return MemberProfileDto.builder()
+    public static CompactProfileDto fromDocument(Member member) {
+        return CompactProfileDto.builder()
                 .memberUuid(member.getMemberUuid())
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
-                .createdAt(member.getCreatedAt())
                 .point(member.getPoint())
                 .grade(member.getGrade())
                 .equippedBadge(member.getEquippedBadge())
-                .followerCount(member.getFollowerCount())
-                .followingCount(member.getFollowingCount())
-                .feedCount(member.getFeedCount())
-                .shortsCount(member.getShortsCount())
                 .build();
     }
 }

--- a/src/main/java/com/mulmeong/member/read/member/infrastructure/MemberRepository.java
+++ b/src/main/java/com/mulmeong/member/read/member/infrastructure/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends MongoRepository<Member, String> {
 
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByMemberUuid(String memberUuid);
 }

--- a/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
@@ -19,12 +19,14 @@ public class KafkaConsumer {
     @KafkaListener(topics = "${event.member.pub.topics.member-create.name}",
             containerFactory = "memberCreateEventListener")
     public void handleMemberCreatedEvent(MemberCreateEvent event) {
+        log.info("Consumed 회원 생성 이벤트 : {}", event);
         memberService.createMember(event);
     }
 
     @KafkaListener(topics = "${event.member.pub.topics.nickname-update.name}",
             containerFactory = "nicknameUpdateEventListener")
     public void handleNicknameUpdatedEvent(MemberNicknameUpdateEvent event) {
+        log.info("Consumed 회원 닉네임 변경 이벤트 : {}", event);
         memberService.updateNickname(event);
     }
 

--- a/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/member/read/member/kafka/KafkaConsumer.java
@@ -6,7 +6,6 @@ import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
 import com.mulmeong.member.read.member.application.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
@@ -17,18 +16,22 @@ public class KafkaConsumer {
 
     private final MemberService memberService;
 
-    @KafkaListener(topics = "member-created", containerFactory = "memberCreateEventListener")
+    @KafkaListener(topics = "${event.member.pub.topics.member-create.name}",
+            containerFactory = "memberCreateEventListener")
     public void handleMemberCreatedEvent(MemberCreateEvent event) {
         memberService.createMember(event);
     }
 
-    @KafkaListener(topics = "nickname-updated", containerFactory = "nicknameUpdateEventListener")
+    @KafkaListener(topics = "${event.member.pub.topics.nickname-update.name}",
+            containerFactory = "nicknameUpdateEventListener")
     public void handleNicknameUpdatedEvent(MemberNicknameUpdateEvent event) {
         memberService.updateNickname(event);
     }
 
-    @KafkaListener(topics = "profile-img-updated", containerFactory = "profileUpdateEventListener")
+    @KafkaListener(topics = "${event.member.pub.topics.profile-img-update.name}",
+            containerFactory = "profileUpdateEventListener")
     public void handleProfileImgUpdatedEvent(MemberProfileImgUpdateEvent event) {
+        log.info("Consumed 프로필 이미지 변경 이벤트 : {}", event);
         memberService.updateProfileImage(event);
     }
 }

--- a/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
+++ b/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package com.mulmeong.member.read.member.presentation;
 
 import com.mulmeong.member.read.common.response.BaseResponse;
 import com.mulmeong.member.read.member.application.MemberService;
+import com.mulmeong.member.read.member.dto.out.CompactProfileDto;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "회원 조회 API", description = "회원 조회 API")
+@Tag(name = "회원 Read-DB API", description = "회원 관련한 조회만 담당하는 서비스 ")
 @RequestMapping("/v1/members")
 @RequiredArgsConstructor
 @RestController
@@ -19,9 +20,23 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "회원 프로필 조회", description = "회원 프로필 화면에 필요한 정보와 회원의 포인트, 뱃지 등을 조회합니다.")
+    @Operation(summary = "닉네임으로 회원 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다. 있는 거 다 꺼내줍니다.")
     @GetMapping("/{nickname}/profile")
-    public BaseResponse<MemberProfileDto> getMemberProfile(@PathVariable String nickname) {
-        return new BaseResponse<>(memberService.getMemberProfile(nickname));
+    public BaseResponse<MemberProfileDto> getMemberProfileByNickname(@PathVariable String nickname) {
+        return new BaseResponse<>(memberService.getProfileByNickname(nickname));
+    }
+
+    @Operation(summary = "회원 UUID로 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다. 있는 거 다 꺼내줍니다.")
+    @GetMapping("/uuid/{memberUuid}/profile")
+    public BaseResponse<MemberProfileDto> getMemberProfileByUuid(@PathVariable String memberUuid) {
+        return new BaseResponse<>(memberService.getProfileByMemberUuid(memberUuid));
+    }
+
+    @Operation(summary = "회원 UUID로 Compact 프로필 조회", description = "회원 닉네임, 프사, 포인트, 뱃지, 등급 반환. "
+            + "피드, 댓글, 쇼츠 등에서 간단한 프로필을 보여줄 때 사용.")
+
+    @GetMapping("/{memberUuid}/compact-profile")
+    public BaseResponse<CompactProfileDto> getCompactProfileByUuid(@PathVariable String memberUuid) {
+        return new BaseResponse<>(memberService.getCompactProfile(memberUuid));
     }
 }


### PR DESCRIPTION
### 📅 2024.11.25

### 🌵 Branch
feature/fix/7 → develop

### 📢 Description
- API 2종 추가(uuid로 프로필정보 조회, uuid로 컴팩트 프로필 조회)
- Kafka Config Generic수정
- kafka EventTopic을 Config에서 불러오도록 수정

### 💬 Issue Number
- #7

### ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 코드가 정상적으로 동작하는지 테스트 했습니다.

### 🔖 Note
별 거 없습니다.