### PR TITLE
[🚀 Member-Read] Reward 서비스 이벤트 consume => 데이터 Sync 구현

### DIFF
--- a/src/main/java/com/mulmeong/event/member/MemberBadgeUpdateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberBadgeUpdateEvent.java
@@ -1,0 +1,23 @@
+package com.mulmeong.event.member;
+
+import com.mulmeong.member.read.member.document.Badge;
+import lombok.Getter;
+
+@Getter
+public class MemberBadgeUpdateEvent {
+    private String memberUuid;
+    private Long badgeId;
+    private String badgeName;
+    private String badgeImageUrl;
+    private String badgeDescription;
+    private boolean equipped;
+
+    public Badge toEntity() {
+        return Badge.builder()
+                .id(badgeId)
+                .name(badgeName)
+                .imageUrl(badgeImageUrl)
+                .description(badgeDescription)
+                .build();
+    }
+}

--- a/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
@@ -22,7 +22,7 @@ public class MemberCreateEvent {
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
                 .createdAt(createdAt)
-                .grade("default") //todo : RewardService에서 계산한 등급으로 변경
+                .grade("플랑크톤") //default grade
                 .followerCount(0)
                 .followingCount(0)
                 .feedCount(0)

--- a/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberCreateEvent.java
@@ -22,7 +22,6 @@ public class MemberCreateEvent {
                 .nickname(nickname)
                 .profileImageUrl(profileImageUrl)
                 .createdAt(createdAt)
-                .point(0)
                 .grade("default") //todo : RewardService에서 계산한 등급으로 변경
                 .followerCount(0)
                 .followingCount(0)

--- a/src/main/java/com/mulmeong/event/member/MemberGradeUpdateEvent.java
+++ b/src/main/java/com/mulmeong/event/member/MemberGradeUpdateEvent.java
@@ -1,0 +1,9 @@
+package com.mulmeong.event.member;
+
+import lombok.Getter;
+
+@Getter
+public class MemberGradeUpdateEvent {
+    private String memberUuid;
+    private String grade;
+}

--- a/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/mulmeong/member/read/common/config/KafkaConsumerConfig.java
@@ -1,9 +1,6 @@
 package com.mulmeong.member.read.common.config;
 
-import com.mulmeong.event.member.MemberBadgeUpdateEvent;
-import com.mulmeong.event.member.MemberCreateEvent;
-import com.mulmeong.event.member.MemberNicknameUpdateEvent;
-import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.event.member.*;
 import com.mulmeong.member.read.common.exception.BaseException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -67,6 +64,14 @@ public class KafkaConsumerConfig {
     public ConcurrentKafkaListenerContainerFactory<String, MemberBadgeUpdateEvent> memberBadgeUpdateEventListener() {
         return kafkaListenerContainerFactory(MemberBadgeUpdateEvent.class);
     }
+
+    /* 멤버 등급 수정 이벤트 리스너 */
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MemberGradeUpdateEvent> memberGradeUpdateEventListener() {
+        return kafkaListenerContainerFactory(MemberGradeUpdateEvent.class);
+    }
+
+
 
     // =================================================================
     // 아래는 공통 설정입니다.

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberEventService.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberEventService.java
@@ -1,0 +1,17 @@
+package com.mulmeong.member.read.member.application;
+
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
+import com.mulmeong.event.member.MemberCreateEvent;
+import com.mulmeong.event.member.MemberNicknameUpdateEvent;
+import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+
+public interface MemberEventService {
+
+    void createMember(MemberCreateEvent memberCreateEvent);
+
+    void updateNickname(MemberNicknameUpdateEvent memberNicknameUpdateEvent);
+
+    void updateProfileImage(MemberProfileImgUpdateEvent memberProfileImgUpdateEvent);
+
+    void updateEquippedBadge(MemberBadgeUpdateEvent memberBadgeUpdateEvent);
+}

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberEventService.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberEventService.java
@@ -1,9 +1,6 @@
 package com.mulmeong.member.read.member.application;
 
-import com.mulmeong.event.member.MemberBadgeUpdateEvent;
-import com.mulmeong.event.member.MemberCreateEvent;
-import com.mulmeong.event.member.MemberNicknameUpdateEvent;
-import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.event.member.*;
 
 public interface MemberEventService {
 
@@ -14,4 +11,6 @@ public interface MemberEventService {
     void updateProfileImage(MemberProfileImgUpdateEvent memberProfileImgUpdateEvent);
 
     void updateEquippedBadge(MemberBadgeUpdateEvent memberBadgeUpdateEvent);
+
+    void updateGrade(MemberGradeUpdateEvent memberGradeUpdateEvent);
 }

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberEventServiceImpl.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberEventServiceImpl.java
@@ -1,0 +1,84 @@
+package com.mulmeong.member.read.member.application;
+
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
+import com.mulmeong.event.member.MemberCreateEvent;
+import com.mulmeong.event.member.MemberNicknameUpdateEvent;
+import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.member.read.member.document.Member;
+import com.mulmeong.member.read.member.infrastructure.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MemberEventServiceImpl implements MemberEventService {
+
+    private final MemberRepository memberRepository;
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * 회원 Read DB 생성.
+     * Write DB에서 회원 생성 이벤트를 받아 처리.
+     *
+     * @param event 회원 생성 Event
+     */
+    @Override
+    public void createMember(MemberCreateEvent event) {
+
+        memberRepository.save(event.toEntity());
+    }
+
+    /**
+     * 회원 Read DB의 닉네임 수정.
+     * Write DB에서 닉네임 수정 이벤트를 받아 처리.
+     *
+     * @param event 닉네임 수정 Event
+     */
+    @Override
+    public void updateNickname(MemberNicknameUpdateEvent event) {
+        updateMemberField(event.getMemberUuid(), "nickname", event.getNickname());
+    }
+
+    /**
+     * 회원 Read DB의 프로필 이미지 수정.
+     * Write DB에서 프로필 이미지 수정 이벤트를 받아 처리.
+     *
+     * @param event 프로필 이미지 수정 Event.
+     */
+    @Override
+    public void updateProfileImage(MemberProfileImgUpdateEvent event) {
+        updateMemberField(event.getMemberUuid(), "profileImageUrl", event.getProfileImgUrl());
+    }
+
+    /**
+     * 회원 Read DB의 장착 뱃지 수정.
+     * 뱃지를 해제한 경우에는 null로 업데이트.
+     *
+     * @param event 뱃지 장착/해제 이벤트
+     */
+    @Override
+    public void updateEquippedBadge(MemberBadgeUpdateEvent event) {
+        updateMemberField(event.getMemberUuid(),
+                "equippedBadge",
+                event.isEquipped() ? event.toEntity() : null);
+    }
+
+    /**
+     * 회원 필드 업데이트하는 private 메서드.
+     *
+     * @param memberUuid 업데이트할 회원의 uuid
+     * @param field      업데이트할 필드(닉네임, 프로필 이미지 URL...)
+     * @param value      업데이트할 값
+     */
+    private void updateMemberField(String memberUuid, String field, Object value) {
+        Query query = new Query(Criteria.where("memberUuid").is(memberUuid));
+        Update update = new Update().set(field, value);
+        mongoTemplate.updateFirst(query, update, Member.class);
+    }
+}

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberEventServiceImpl.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberEventServiceImpl.java
@@ -1,9 +1,6 @@
 package com.mulmeong.member.read.member.application;
 
-import com.mulmeong.event.member.MemberBadgeUpdateEvent;
-import com.mulmeong.event.member.MemberCreateEvent;
-import com.mulmeong.event.member.MemberNicknameUpdateEvent;
-import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.event.member.*;
 import com.mulmeong.member.read.member.document.Member;
 import com.mulmeong.member.read.member.infrastructure.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +21,7 @@ public class MemberEventServiceImpl implements MemberEventService {
 
     /**
      * 회원 Read DB 생성.
-     * Write DB에서 회원 생성 이벤트를 받아 처리.
+     * Write DB에서 회원 생성 이벤트를 받아 처리. 회원가입시 모르는 정보는 기본값으로 변환해 저장.
      *
      * @param event 회원 생성 Event
      */
@@ -67,6 +64,16 @@ public class MemberEventServiceImpl implements MemberEventService {
         updateMemberField(event.getMemberUuid(),
                 "equippedBadge",
                 event.isEquipped() ? event.toEntity() : null);
+    }
+
+    /**
+     * 회원 Read DB의 등급 업데이트.
+     *
+     * @param event 등급 업데이트 이벤트
+     */
+    @Override
+    public void updateGrade(MemberGradeUpdateEvent event) {
+        updateMemberField(event.getMemberUuid(), "grade", event.getGrade());
     }
 
     /**

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberHttpHttpServiceImpl.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberHttpHttpServiceImpl.java
@@ -19,47 +19,13 @@ import static com.mulmeong.member.read.common.response.BaseResponseStatus.NOT_FO
 
 @RequiredArgsConstructor
 @Service
-public class MemberServiceImpl implements MemberService {
+public class MemberHttpHttpServiceImpl implements MemberHttpService {
 
     private final MemberRepository memberRepository;
     private final MongoTemplate mongoTemplate;
 
     /**
-     * 회원 Read DB 생성.
-     * Write DB에서 회원 생성 이벤트를 받아 처리.
-     *
-     * @param event 회원 생성 Event
-     */
-    @Override
-    public void createMember(MemberCreateEvent event) {
-
-        memberRepository.save(event.toEntity());
-    }
-
-    /**
-     * 회원 Read DB의 닉네임 수정.
-     * Write DB에서 닉네임 수정 이벤트를 받아 처리.
-     *
-     * @param event 닉네임 수정 Event
-     */
-    @Override
-    public void updateNickname(MemberNicknameUpdateEvent event) {
-        updateMemberField(event.getMemberUuid(), "nickname", event.getNickname());
-    }
-
-    /**
-     * 회원 Read DB의 프로필 이미지 수정.
-     * Write DB에서 프로필 이미지 수정 이벤트를 받아 처리.
-     *
-     * @param event 프로필 이미지 수정 Event.
-     */
-    @Override
-    public void updateProfileImage(MemberProfileImgUpdateEvent event) {
-        updateMemberField(event.getMemberUuid(), "profileImageUrl", event.getProfileImgUrl());
-    }
-
-    /**
-     * 회원 프로필 조회 API
+     * 닉네임으로 회원 프로필 조회 API
      * 등록/수정이 되지 않은 필드들은 기본값으로 반환.(예: 집계데이터들).
      *
      * @param nickname 회원 닉네임
@@ -73,10 +39,10 @@ public class MemberServiceImpl implements MemberService {
     }
 
     /**
-     * 회원 프로필 조회 API
+     * 회원 uuid로 회원 프로필 조회 API
      * 등록/수정이 되지 않은 필드들은 기본값으로 반환됩니다.(예: 집계데이터들).
      *
-     * @param memberUuid 회원 닉네임
+     * @param memberUuid 회원 uuid
      * @return 회원 프로필 DTO(Member Document와 같음)
      */
     @Override
@@ -98,18 +64,5 @@ public class MemberServiceImpl implements MemberService {
         return memberRepository.findByMemberUuid(memberUuid)
                 .map(CompactProfileDto::fromDocument)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
-    }
-
-    /**
-     * 회원 필드 업데이트하는 private 메서드.
-     *
-     * @param memberUuid 업데이트할 회원의 uuid
-     * @param field      업데이트할 필드(닉네임, 프로필 이미지 URL...)
-     * @param value      업데이트할 값
-     */
-    private void updateMemberField(String memberUuid, String field, Object value) {
-        Query query = new Query(Criteria.where("memberUuid").is(memberUuid));
-        Update update = new Update().set(field, value);
-        mongoTemplate.updateFirst(query, update, Member.class);
     }
 }

--- a/src/main/java/com/mulmeong/member/read/member/application/MemberHttpService.java
+++ b/src/main/java/com/mulmeong/member/read/member/application/MemberHttpService.java
@@ -1,18 +1,13 @@
 package com.mulmeong.member.read.member.application;
 
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
 import com.mulmeong.event.member.MemberCreateEvent;
 import com.mulmeong.event.member.MemberNicknameUpdateEvent;
 import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
 import com.mulmeong.member.read.member.dto.out.CompactProfileDto;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
 
-public interface MemberService {
-
-    void createMember(MemberCreateEvent memberCreateEvent);
-
-    void updateNickname(MemberNicknameUpdateEvent memberNicknameUpdateEvent);
-
-    void updateProfileImage(MemberProfileImgUpdateEvent memberProfileImgUpdateEvent);
+public interface MemberHttpService {
 
     MemberProfileDto getProfileByNickname(String nickname);
 

--- a/src/main/java/com/mulmeong/member/read/member/document/Badge.java
+++ b/src/main/java/com/mulmeong/member/read/member/document/Badge.java
@@ -1,11 +1,15 @@
 package com.mulmeong.member.read.member.document;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
+@Builder
 public class Badge {
-    private Integer badgeId;
-    private String badgeName;
-    private String badgeImageUrl;
-    private String badgeDescription;
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String description;
 }

--- a/src/main/java/com/mulmeong/member/read/member/document/Member.java
+++ b/src/main/java/com/mulmeong/member/read/member/document/Member.java
@@ -24,8 +24,7 @@ public class Member {
     private String nickname;
     private String profileImageUrl;
     private LocalDateTime createdAt;
-    private Integer point;
-    private String grade;
+    private String grade; // 등급 이름
     private Badge equippedBadge;
     // todo : 화면에 따른 기타 집계 데이터 추가/수정 필요
     private Integer followerCount;
@@ -34,14 +33,13 @@ public class Member {
     private Integer shortsCount;
 
     @Builder
-    public Member(String memberUuid, String nickname, String profileImageUrl, LocalDateTime createdAt, Integer point,
+    public Member(String memberUuid, String nickname, String profileImageUrl, LocalDateTime createdAt,
                   String grade, Badge equippedBadge, Integer followerCount, Integer followingCount, Integer feedCount,
                   Integer shortsCount) {
         this.memberUuid = memberUuid;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         this.createdAt = createdAt;
-        this.point = point;
         this.grade = grade;
         this.equippedBadge = equippedBadge;
         this.followerCount = followerCount;

--- a/src/main/java/com/mulmeong/member/read/member/dto/out/CompactProfileDto.java
+++ b/src/main/java/com/mulmeong/member/read/member/dto/out/CompactProfileDto.java
@@ -13,7 +13,6 @@ public class CompactProfileDto {
     private String memberUuid;
     private String nickname;
     private String profileImageUrl;
-    private Integer point;
     private String grade;
     private Badge equippedBadge;
 
@@ -22,7 +21,6 @@ public class CompactProfileDto {
                 .memberUuid(member.getMemberUuid())
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
-                .point(member.getPoint())
                 .grade(member.getGrade())
                 .equippedBadge(member.getEquippedBadge())
                 .build();

--- a/src/main/java/com/mulmeong/member/read/member/dto/out/MemberProfileDto.java
+++ b/src/main/java/com/mulmeong/member/read/member/dto/out/MemberProfileDto.java
@@ -20,7 +20,6 @@ public class MemberProfileDto {
     private String nickname;
     private String profileImageUrl;
     private LocalDateTime createdAt;
-    private Integer point;
     private String grade;
     private Badge equippedBadge;
     private Integer followerCount;
@@ -34,7 +33,6 @@ public class MemberProfileDto {
                 .nickname(member.getNickname())
                 .profileImageUrl(member.getProfileImageUrl())
                 .createdAt(member.getCreatedAt())
-                .point(member.getPoint())
                 .grade(member.getGrade())
                 .equippedBadge(member.getEquippedBadge())
                 .followerCount(member.getFollowerCount())

--- a/src/main/java/com/mulmeong/member/read/member/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/member/read/member/infrastructure/KafkaConsumer.java
@@ -1,9 +1,6 @@
 package com.mulmeong.member.read.member.infrastructure;
 
-import com.mulmeong.event.member.MemberBadgeUpdateEvent;
-import com.mulmeong.event.member.MemberCreateEvent;
-import com.mulmeong.event.member.MemberNicknameUpdateEvent;
-import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
+import com.mulmeong.event.member.*;
 import com.mulmeong.member.read.member.application.MemberEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,5 +40,12 @@ public class KafkaConsumer {
     public void handleMemberBadgeUpdatedEvent(MemberBadgeUpdateEvent event) {
         log.info("Consumed 회원 뱃지 변경 이벤트 : {}", event);
         memberService.updateEquippedBadge(event);
+    }
+
+    @KafkaListener(topics = "${event.grade.pub.topics.member-grade-update.name}",
+            containerFactory = "memberBadgeCreateEventListener")
+    public void handleMemberGradeUpdatedEvent(MemberGradeUpdateEvent event) {
+        log.info("Consumed 회원 등급 변경 이벤트 : {}", event);
+        memberService.updateGrade(event);
     }
 }

--- a/src/main/java/com/mulmeong/member/read/member/infrastructure/KafkaConsumer.java
+++ b/src/main/java/com/mulmeong/member/read/member/infrastructure/KafkaConsumer.java
@@ -1,9 +1,10 @@
-package com.mulmeong.member.read.member.kafka;
+package com.mulmeong.member.read.member.infrastructure;
 
+import com.mulmeong.event.member.MemberBadgeUpdateEvent;
 import com.mulmeong.event.member.MemberCreateEvent;
 import com.mulmeong.event.member.MemberNicknameUpdateEvent;
 import com.mulmeong.event.member.MemberProfileImgUpdateEvent;
-import com.mulmeong.member.read.member.application.MemberService;
+import com.mulmeong.member.read.member.application.MemberEventService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -14,7 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class KafkaConsumer {
 
-    private final MemberService memberService;
+    private final MemberEventService memberService;
 
     @KafkaListener(topics = "${event.member.pub.topics.member-create.name}",
             containerFactory = "memberCreateEventListener")
@@ -35,5 +36,12 @@ public class KafkaConsumer {
     public void handleProfileImgUpdatedEvent(MemberProfileImgUpdateEvent event) {
         log.info("Consumed 프로필 이미지 변경 이벤트 : {}", event);
         memberService.updateProfileImage(event);
+    }
+
+    @KafkaListener(topics = "${event.badge.pub.topics.member-badge-update.name}",
+            containerFactory = "memberBadgeUpdateEventListener")
+    public void handleMemberBadgeUpdatedEvent(MemberBadgeUpdateEvent event) {
+        log.info("Consumed 회원 뱃지 변경 이벤트 : {}", event);
+        memberService.updateEquippedBadge(event);
     }
 }

--- a/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
+++ b/src/main/java/com/mulmeong/member/read/member/presentation/MemberController.java
@@ -1,7 +1,7 @@
 package com.mulmeong.member.read.member.presentation;
 
 import com.mulmeong.member.read.common.response.BaseResponse;
-import com.mulmeong.member.read.member.application.MemberService;
+import com.mulmeong.member.read.member.application.MemberHttpService;
 import com.mulmeong.member.read.member.dto.out.CompactProfileDto;
 import com.mulmeong.member.read.member.dto.out.MemberProfileDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,18 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class MemberController {
 
-    private final MemberService memberService;
+    private final MemberHttpService memberHttpService;
 
-    @Operation(summary = "닉네임으로 회원 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다. 있는 거 다 꺼내줍니다.")
+    @Operation(summary = "닉네임으로 회원 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다. "
+            + "설계 변경으로 포인트는 Reward 서비스로 이동했습니다.")
     @GetMapping("/{nickname}/profile")
     public BaseResponse<MemberProfileDto> getMemberProfileByNickname(@PathVariable String nickname) {
-        return new BaseResponse<>(memberService.getProfileByNickname(nickname));
+        return new BaseResponse<>(memberHttpService.getProfileByNickname(nickname));
     }
 
-    @Operation(summary = "회원 UUID로 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다. 있는 거 다 꺼내줍니다.")
+    @Operation(summary = "회원 UUID로 프로필 조회", description = "회원 프로필 화면에 필요한 정보를 조회합니다."
+            + "설계 변경으로 포인트는 Reward 서비스로 이동했습니다.")
     @GetMapping("/uuid/{memberUuid}/profile")
     public BaseResponse<MemberProfileDto> getMemberProfileByUuid(@PathVariable String memberUuid) {
-        return new BaseResponse<>(memberService.getProfileByMemberUuid(memberUuid));
+        return new BaseResponse<>(memberHttpService.getProfileByMemberUuid(memberUuid));
     }
 
     @Operation(summary = "회원 UUID로 Compact 프로필 조회", description = "회원 닉네임, 프사, 포인트, 뱃지, 등급 반환. "
@@ -37,6 +39,6 @@ public class MemberController {
 
     @GetMapping("/{memberUuid}/compact-profile")
     public BaseResponse<CompactProfileDto> getCompactProfileByUuid(@PathVariable String memberUuid) {
-        return new BaseResponse<>(memberService.getCompactProfile(memberUuid));
+        return new BaseResponse<>(memberHttpService.getCompactProfile(memberUuid));
     }
 }


### PR DESCRIPTION
<!-- Title: [🚀 (Service名)] (AAA) 기능 구현 -->
<!-- Merge 방향 및 Branch 확인해주세요 -->
<!-- (괄호) 부분은 다 지우고 작성해주세요 -->

### 📅 2024.12.10

### 🌵 Branch
develop → release

### 📢 Description
설계 변경 및 Reward 서비스 변경에 따른 Read-DB 반영 구현
- [x] Member-Read-DB에 포인트 삭제
- [x] 회원 장착 배지 생성/수정시 이벤트 Consume
- [x] 등급 변경시 이벤트 Consume
- [x] Kafka ConsumerConfig 수정

이하 Pull Request 및 Issue 내용 참고

### 📦 Pull Request Number
- #12

### 💬 Issue Number
- #10

### 🔖 Note
(참고사항을 적어주세요)